### PR TITLE
Pから始まる語、RQPから始まる語を除く処理を加えることで平行移動を取り除いた close #6

### DIFF
--- a/src/dfs/DFSOperator.java
+++ b/src/dfs/DFSOperator.java
@@ -80,7 +80,12 @@ public class DFSOperator {
 
 	private boolean branchTermination(int maxLevel, double epsilon){
 		if(level == maxLevel){
+			if((tags[1] == 2 && tags[2] == 1 && tags[3] == 0) ||
+			   tags[1] == 0){
+				return true;
+			}
 			pointsList.add(Mobius.mobiusOnPoint(words[level], Complex.INFINITY));
+			
 			return true;
 		}
 		

--- a/src/ui/Display.java
+++ b/src/ui/Display.java
@@ -23,12 +23,12 @@ public class Display extends JPanel{
 	private boolean isDraggingR = false;
 
 	
-	private int maxLevel = 15;
+	private int maxLevel = 20;
 	private double epsilon = 0.002;
 	private ArrayList<Complex> points = new ArrayList<>();
 	public Display(){
-		Complex a1 = new Complex(0.3, 0.4);
-		Complex a2 = new Complex(0.3, 0.1);
+		Complex a1 = new Complex(0.25, 0);
+		Complex a2 = new Complex(0.25, 0);
 		cp = new ComplexProbability(a1, a2, Complex.ZERO);
 		cp.setColor(Color.red);
 		cp2 = cp.replace(1);
@@ -52,8 +52,9 @@ public class Display extends JPanel{
 		
 		g2.translate(getWidth() / 2, getHeight() / 2 );
 //		System.out.println(points.size());
-		for(int i = 0 ; i < points.size()-1 ; i++){
+		for(int i = 0 ; i < points.size(); i++){
 			Complex point = points.get(i);
+//			System.out.println(point);
 			g2.fillRect((int) (point.re() * magnification), (int) (point.im() * magnification), 2, 2);
 		}
 	}


### PR DESCRIPTION
Pから始まる語、RQPから始まる語を除くことで平行移動する点を除くことができると判明した。平行移動で終わる語を除く方法はうまくいかなかった。
